### PR TITLE
Removed line break from links returned by bit.ly

### DIFF
--- a/system/expressionengine/third_party/shorteen/mod.shorteen.php
+++ b/system/expressionengine/third_party/shorteen/mod.shorteen.php
@@ -236,6 +236,9 @@ class Shorteen {
                     $shorturl = $rawdata->url;
                 }
                 break;
+            case 'bitly':
+                $shorturl = preg_replace('/\r|\n/', '', $response);
+                break;
             default:
                 $shorturl = $response;
                 break;


### PR DESCRIPTION
I noticed that the links returned by the bit.ly service contained a line break at the end, which can sometimes be a problem.
