### PR TITLE
Update mod.shorteen.php

### DIFF
--- a/system/expressionengine/third_party/shorteen/mod.shorteen.php
+++ b/system/expressionengine/third_party/shorteen/mod.shorteen.php
@@ -178,7 +178,7 @@ class Shorteen {
         curl_setopt($ch, CURLOPT_USERAGENT, 'Shorteen ExpressionEngine Add-on');
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-        //curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+        curl_setopt($ch, CURLOPT_SSLVERSION, 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
CURLOPT_SSLVERSION 0 is the default and attempts to negotiate the best option. It avoids error 35 SSL Connection errors.